### PR TITLE
Add strike-based game

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -1,4 +1,67 @@
-// Wait for the DOM to be fully loaded
+// Game logic for strike-based target game
+
 document.addEventListener('DOMContentLoaded', () => {
-    console.log('Hello World from JavaScript!');
-}); 
+    const board = document.getElementById('gameboard');
+    const target = document.getElementById('target');
+    const strikeCounter = document.getElementById('strike-counter');
+    const message = document.getElementById('message');
+    const replayBtn = document.getElementById('replay');
+
+    let strikes = 0;
+    let timerId = null;
+
+    function updateStrikes() {
+        strikeCounter.textContent = `Strikes: ${strikes}`;
+    }
+
+    function randomPosition() {
+        const maxX = board.clientWidth - target.offsetWidth;
+        const maxY = board.clientHeight - target.offsetHeight;
+        const x = Math.floor(Math.random() * maxX);
+        const y = Math.floor(Math.random() * maxY);
+        target.style.left = `${x}px`;
+        target.style.top = `${y}px`;
+    }
+
+    function showTarget() {
+        target.classList.remove('hidden');
+        randomPosition();
+        timerId = setTimeout(missedTarget, 1000);
+    }
+
+    function missedTarget() {
+        strikes += 1;
+        updateStrikes();
+        if (strikes >= 3) {
+            endGame();
+        } else {
+            showTarget();
+        }
+    }
+
+    function endGame() {
+        clearTimeout(timerId);
+        target.classList.add('hidden');
+        message.classList.remove('hidden');
+        message.textContent = 'End Game';
+        replayBtn.classList.remove('hidden');
+    }
+
+    function startGame() {
+        strikes = 0;
+        updateStrikes();
+        message.classList.add('hidden');
+        replayBtn.classList.add('hidden');
+        showTarget();
+    }
+
+    target.addEventListener('click', () => {
+        clearTimeout(timerId);
+        showTarget();
+    });
+
+    replayBtn.addEventListener('click', startGame);
+
+    startGame();
+});
+

--- a/index.html
+++ b/index.html
@@ -3,11 +3,17 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Sharks Project</title>
+    <title>Sharks Game</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <h1>Hello World</h1>
+    <div id="gameboard">
+        <div id="strike-counter">Strikes: 0</div>
+        <div id="message" class="hidden">End Game</div>
+        <button id="target" class="hidden"></button>
+        <button id="replay" class="hidden">Replay</button>
+    </div>
+
     <script src="functions.js"></script>
 </body>
-</html> 
+</html>

--- a/style.css
+++ b/style.css
@@ -8,7 +8,49 @@ body {
     background-color: #f0f0f0;
 }
 
-h1 {
-    color: #333;
+#gameboard {
+    position: relative;
+    width: 400px;
+    height: 400px;
+    background-color: #fff;
+    border: 2px solid #333;
+    overflow: hidden;
+}
+
+#strike-counter {
+    position: absolute;
+    top: 5px;
+    left: 5px;
+    font-weight: bold;
+}
+
+#message {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 24px;
     text-align: center;
-} 
+}
+
+#target {
+    position: absolute;
+    width: 40px;
+    height: 40px;
+    background-color: red;
+    border: none;
+    border-radius: 50%;
+    cursor: pointer;
+}
+
+#replay {
+    position: absolute;
+    top: 60%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    padding: 10px 20px;
+}
+
+.hidden {
+    display: none;
+}


### PR DESCRIPTION
## Summary
- replace placeholder page with simple strike game
- style board and scoreboard
- implement strike logic with 3-strike limit and replay option

## Testing
- `node -e "require('./functions.js')"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6841f7950784833185697000cd25b5d1