### PR TITLE
Add strike counter with replay

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -3,8 +3,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const levelDisplay = document.getElementById('level');
     const tileSize = 40;
     let level = 1;
+    let strikes = 0;
     let player;
     let sharks = [];
+    let gameOver = false;
+    let animationId;
+
+    const strikeDisplay = document.getElementById('strikes');
+    const replayButton = document.getElementById('replay');
 
     function createPlayer(height, width) {
         player = document.createElement('div');
@@ -41,6 +47,21 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
+    function updateStrikes() {
+        strikeDisplay.textContent = strikes;
+    }
+
+    function handleStrike() {
+        strikes++;
+        updateStrikes();
+        if (strikes >= 3) {
+            gameOver = true;
+            replayButton.style.display = 'block';
+        } else {
+            startLevel();
+        }
+    }
+
     function movePlayer(dx, dy) {
         const newLeft = Math.max(0, Math.min(gameArea.clientWidth - 30, player.offsetLeft + dx));
         const newTop = Math.max(0, Math.min(gameArea.clientHeight - 30, player.offsetTop + dy));
@@ -59,6 +80,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function animate() {
+        if (gameOver) return;
         sharks.forEach(shark => {
             const speed = parseFloat(shark.dataset.speed);
             let left = shark.offsetLeft + speed * parseFloat(shark.dataset.direction);
@@ -69,11 +91,13 @@ document.addEventListener('DOMContentLoaded', () => {
                 left = gameArea.clientWidth;
             }
             shark.style.left = left + 'px';
-            if (isColliding(player, shark)) {
-                startLevel();
+            if (!gameOver && isColliding(player, shark)) {
+                handleStrike();
             }
         });
-        requestAnimationFrame(animate);
+        if (!gameOver) {
+            animationId = requestAnimationFrame(animate);
+        }
     }
 
     document.addEventListener('keydown', (e) => {
@@ -83,6 +107,17 @@ document.addEventListener('DOMContentLoaded', () => {
         if (e.key === 'ArrowRight') movePlayer(tileSize / 2, 0);
     });
 
+    replayButton.addEventListener('click', () => {
+        strikes = 0;
+        updateStrikes();
+        level = 1;
+        gameOver = false;
+        replayButton.style.display = 'none';
+        startLevel();
+        animationId = requestAnimationFrame(animate);
+    });
+
     startLevel();
-    requestAnimationFrame(animate);
+    updateStrikes();
+    animationId = requestAnimationFrame(animate);
 });

--- a/index.html
+++ b/index.html
@@ -7,8 +7,12 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <div id="info">Level: <span id="level">1</span></div>
+    <div id="info">
+        <span>Level: <span id="level">1</span></span>
+        <span>Strikes: <span id="strikes">0</span></span>
+    </div>
     <div id="gameArea"></div>
+    <button id="replay" style="display:none;">Replay</button>
     <script src="functions.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -13,6 +13,15 @@ body {
     margin: 10px;
     font-size: 20px;
     color: #fff;
+    display: flex;
+    justify-content: space-between;
+    width: 400px;
+}
+
+#replay {
+    margin-top: 10px;
+    padding: 5px 10px;
+    font-size: 16px;
 }
 
 #gameArea {


### PR DESCRIPTION
## Summary
- show level and strikes above the board
- style new strike display and replay button
- track strikes in the game logic and stop after three
- add replay button to restart the game

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68443f8a00648331a9197ea301204c0a