### PR TITLE
Add game over screen and button spacing

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -11,6 +11,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const strikeDisplay = document.getElementById('strikes');
     const replayButton = document.getElementById('replay');
+    const gameOverText = document.getElementById('gameOver');
 
     function createPlayer(height, width) {
         player = document.createElement('div');
@@ -57,6 +58,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (strikes >= 3) {
             gameOver = true;
             replayButton.style.display = 'block';
+            gameOverText.style.display = 'block';
         } else {
             startLevel();
         }
@@ -112,6 +114,7 @@ document.addEventListener('DOMContentLoaded', () => {
         updateStrikes();
         level = 1;
         gameOver = false;
+        gameOverText.style.display = 'none';
         replayButton.style.display = 'none';
         startLevel();
         animationId = requestAnimationFrame(animate);

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
         <span>Strikes: <span id="strikes">0</span></span>
     </div>
     <div id="gameArea"></div>
+    <div id="gameOver" style="display:none;">Game Over</div>
     <button id="replay" style="display:none;">Replay</button>
     <script src="functions.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -24,8 +24,20 @@ body {
 
 #replay {
     margin-top: 10px;
+    margin-bottom: 20px;
     padding: 5px 10px;
     font-size: 16px;
+}
+
+#gameOver {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    color: #fff;
+    font-size: 48px;
+    display: none;
+    z-index: 1000;
 }
 
 #gameArea {


### PR DESCRIPTION
## Summary
- show a big white `Game Over` message when the player loses
- add space below the replay button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6844436787ec8331b383cf37bfeee8be