### PR TITLE
Add random shark count per row

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -41,10 +41,13 @@ document.addEventListener('DOMContentLoaded', () => {
         gameArea.style.height = height + 'px';
         levelDisplay.textContent = level;
         createPlayer(height, width);
-        const sharkCount = 2 + (level - 1);
-        for (let i = 0; i < sharkCount; i++) {
-            const top = tileSize + (i % (level + 1)) * tileSize;
-            createShark(top, 1 + level * 0.5);
+        const rows = level + 1;
+        for (let row = 0; row < rows; row++) {
+            const top = tileSize + row * tileSize;
+            const sharksInRow = Math.floor(Math.random() * Math.min(3, level)) + 1;
+            for (let i = 0; i < sharksInRow; i++) {
+                createShark(top, 1 + level * 0.5);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- modify `startLevel` to spawn up to three sharks per lane

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6844489a86b0833186dbea7b1e7789e4