### PR TITLE
Fix shark spawn row logic

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -116,7 +116,7 @@ document.addEventListener('DOMContentLoaded', () => {
         for (let i = 0; i < INITIAL_SHARKS; i++) {
             const row = getAvailableRow(rows);
             if (row === null) break;
-            const top = tileSize + row * tileSize;
+            const top = height - tileSize * (row + 1);
             createShark(row, top, 1 + level * 0.5);
         }
     }
@@ -157,7 +157,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 const rows = level + 1;
                 const row = getAvailableRow(rows);
                 if (row !== null) {
-                    const top = tileSize + row * tileSize;
+                    const top = gameArea.clientHeight - tileSize * (row + 1);
                     createShark(row, top, 1 + level * 0.5);
                 }
             }


### PR DESCRIPTION
## Summary
- let sharks spawn on swimmer's starting row by calculating row positions from the bottom

## Testing
- `node --check functions.js`

------
https://chatgpt.com/codex/tasks/task_e_68445cccc0c08331950cd772d0c235a3