### PR TITLE
Center game over message

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -1,6 +1,7 @@
 // Wait for the DOM to be fully loaded
 document.addEventListener('DOMContentLoaded', () => {
     const container = document.querySelector('.shark-container');
+    const gameOverEl = document.getElementById('gameOver');
     if (!container) {
         console.error('Shark container not found');
         return;
@@ -17,4 +18,11 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     console.log(`Loaded ${sharkCount} shark(s)`);
+
+    // Simulate a game over condition after loading the sharks
+    if (gameOverEl) {
+        setTimeout(() => {
+            gameOverEl.style.display = 'block';
+        }, 2000);
+    }
 });

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <div class="container">
         <div class="shark-container"></div>
         <img src="https://upload.wikimedia.org/wikipedia/commons/3/32/Swimming_Freestyle_Silhouette.svg" alt="Swimmer in action" class="swimmer">
+        <div id="gameOver" class="game-over">Game Over!</div>
     </div>
     <script src="functions.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -13,6 +13,7 @@ body {
     display: flex;
     align-items: center;
     gap: 20px;
+    position: relative;
 }
 
 .shark-container {
@@ -33,4 +34,18 @@ body {
 h1 {
     color: #333;
     text-align: center;
+}
+
+.game-over {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    padding: 20px;
+    background: rgba(255, 255, 255, 0.9);
+    border: 2px solid red;
+    color: red;
+    font-size: 2rem;
+    display: none;
+    z-index: 10;
 }


### PR DESCRIPTION
## Summary
- add a hidden Game Over element in the main container
- center the message with absolute positioning
- reveal the Game Over overlay after the sharks load

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684556cf39f883319150184bd59c2aea