### PR TITLE
Fix game over visibility

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -106,6 +106,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function startLevel() {
         gameArea.innerHTML = '';
+        gameArea.appendChild(gameOverText);
+        gameOverText.style.display = 'none';
         sharks = [];
         sharksPerRow = {};
         const width = 400;


### PR DESCRIPTION
## Summary
- keep the game over div inside the game area when resetting levels
- ensure the message is hidden until game end

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845636701e083319fd0e35294fc0130